### PR TITLE
Fix to the routine that opens the MIDI file.

### DIFF
--- a/SpaceCadetPinball/midi.cpp
+++ b/SpaceCadetPinball/midi.cpp
@@ -54,9 +54,9 @@ int midi::music_init(HWND hwnd)
 	mci_open_info.wDeviceID = 0;
 	midi_notify_hwnd = hwnd;
 	lstrcpyA(midi_device_type, pinball::get_rc_string(156, 0));
-	mci_open_info.lpstrElementName = nullptr;
-	mci_open_info.lpstrDeviceType = midi_device_type;
-	auto result = mciSendCommandA(0, MCI_OPEN, MCI_OPEN_TYPE | MCI_NOTIFY_SUPERSEDED, (DWORD_PTR)&mci_open_info);
+	mci_open_info.lpstrElementName = midi_device_type;
+	mci_open_info.lpstrDeviceType = nullptr;
+	auto result = mciSendCommandA(0, MCI_OPEN, MCI_OPEN_ELEMENT | MCI_NOTIFY_SUPERSEDED, (DWORD_PTR)&mci_open_info);
 	midi_seq1_open = result == 0;
 	return midi_seq1_open;
 }


### PR DESCRIPTION
In the original source code for Space Cadet and its related games, the MIDI sound track is opened with MCI_OPEN_TYPE. According to Microsoft's documentation (https://docs.microsoft.com/en-us/windows/win32/multimedia/mci-open), this is for opening devices and not files. Windows' libraries were obviously robust enough to accommodate the error, but other platforms (i.e. WINE) expects things to be called the right way. The simple fix is to switch out MCI_OPEN_TYPE with MCI_OPEN_ELEMENT and move the info for the filename to the lpstrElementName variable.