### PR TITLE
Add an option to show or hide the menu

### DIFF
--- a/SpaceCadetPinball/options.cpp
+++ b/SpaceCadetPinball/options.cpp
@@ -65,6 +65,7 @@ void options::init()
 
 	Options.Sounds = 1;
 	Options.Music = 0;
+	Options.ShowMenu = 1;
 	Options.FullScreen = 0;
 	Options.LeftFlipperKeyDft = SDLK_z;
 	Options.RightFlipperKeyDft = SDLK_SLASH;
@@ -88,6 +89,7 @@ void options::init()
 	Options.UniformScaling = true;
 	Options.Sounds = get_int("Sounds", Options.Sounds);
 	Options.Music = get_int("Music", Options.Music);
+	Options.ShowMenu = get_int("ShowMenu", Options.ShowMenu);
 	Options.FullScreen = get_int("FullScreen", Options.FullScreen);
 	Options.Players = get_int("Players", Options.Players);
 	Options.LeftFlipperKey = get_int("Left Flipper key", Options.LeftFlipperKey);
@@ -118,6 +120,7 @@ void options::uninit()
 {
 	set_int("Sounds", Options.Sounds);
 	set_int("Music", Options.Music);
+	set_int("ShowMenu", Options.ShowMenu);
 	set_int("FullScreen", Options.FullScreen);
 	set_int("Players", Options.Players);
 	set_int("Left Flipper key", Options.LeftFlipperKey);
@@ -185,6 +188,9 @@ void options::toggle(Menu1 uIDCheckItem)
 			midi::music_stop();
 		else
 			midi::play_pb_theme(0);
+		return;
+	case Menu1::Show_Menu:
+		Options.ShowMenu = Options.ShowMenu == 0;
 		return;
 	case Menu1::Full_Screen:
 		newValue = Options.FullScreen == 0;

--- a/SpaceCadetPinball/options.h
+++ b/SpaceCadetPinball/options.h
@@ -20,6 +20,7 @@ enum class Menu1:int
 	TwoPlayers = 409,
 	ThreePlayers = 410,
 	FourPlayers = 411,
+	Show_Menu = 412,
 	MaximumResolution = 500,
 	R640x480 = 501,
 	R800x600 = 502,
@@ -32,6 +33,7 @@ struct optionsStruct
 {
 	int Sounds;
 	int Music;
+	int ShowMenu;
 	int FullScreen;
 	int Players;
 	int LeftFlipperKey;

--- a/SpaceCadetPinball/winmain.cpp
+++ b/SpaceCadetPinball/winmain.cpp
@@ -584,7 +584,7 @@ int winmain::event_handler(const SDL_Event* event)
 				pause();
 			options::keyboard();
 			break;
-		case SDLK_F0:
+		case SDLK_F9:
 			options::toggle(Menu1::Show_Menu);
 			break;
 		default:

--- a/SpaceCadetPinball/winmain.cpp
+++ b/SpaceCadetPinball/winmain.cpp
@@ -244,16 +244,23 @@ int winmain::WinMain(LPCSTR lpCmdLine)
 			if (UpdateToFrameCounter >= UpdateToFrameRatio)
 			{
 				UpdateToFrameCounter -= UpdateToFrameRatio;
-				ImGui_ImplSDL2_NewFrame();
-				ImGui::NewFrame();
 
-				RenderUi();
+				if (options::Options.ShowMenu)
+				{
+					ImGui_ImplSDL2_NewFrame();
+					ImGui::NewFrame();
+
+					RenderUi();
+				}
 
 				SDL_RenderClear(renderer);
 				render::PresentVScreen();
 
-				ImGui::Render();
-				ImGuiSDL::Render(ImGui::GetDrawData());
+				if (options::Options.ShowMenu)
+				{
+					ImGui::Render();
+					ImGuiSDL::Render(ImGui::GetDrawData());
+				}
 
 				SDL_RenderPresent(renderer);
 				frameCounter++;
@@ -353,6 +360,10 @@ void winmain::RenderUi()
 
 		if (ImGui::BeginMenu("Options"))
 		{
+			if (ImGui::MenuItem("Show Menu", "F5", options::Options.ShowMenu))
+			{
+				options::toggle(Menu1::Show_Menu);
+			}
 			if (ImGui::MenuItem("Full Screen", "F4", options::Options.FullScreen))
 			{
 				options::toggle(Menu1::Full_Screen);

--- a/SpaceCadetPinball/winmain.cpp
+++ b/SpaceCadetPinball/winmain.cpp
@@ -360,7 +360,7 @@ void winmain::RenderUi()
 
 		if (ImGui::BeginMenu("Options"))
 		{
-			if (ImGui::MenuItem("Show Menu", "F5", options::Options.ShowMenu))
+			if (ImGui::MenuItem("Show Menu", "F9", options::Options.ShowMenu))
 			{
 				options::toggle(Menu1::Show_Menu);
 			}
@@ -583,6 +583,9 @@ int winmain::event_handler(const SDL_Event* event)
 			if (!single_step)
 				pause();
 			options::keyboard();
+			break;
+		case SDLK_F0:
+			options::toggle(Menu1::Show_Menu);
 			break;
 		default:
 			break;


### PR DESCRIPTION
This add an checkbox (in the menu itself, with key F5 as well) "Show Menu", enabled/checked by default.

This option is useful in case the pinball is the only item displayed on the screen, in my case, as a fun addition on my mini arcade machine (https://i.imgur.com/nz3u48A.jpg) :slightly_smiling_face: 

Didn't tested it yet, i'll update the PR after it has been tested