### PR TITLE
fix: lint README to make more linkable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Supports data files from Windows and Full Tilt versions of the game.
 
 Platforms covered by this project: desktop Windows, Linux and macOS.
 
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+
 ## Source
 
 * `pinball.exe` from `Windows XP` (SHA-1 `2A5B525E0F631BB6107639E2A69DF15986FB0D05`) and its public PDB

--- a/README.md
+++ b/README.md
@@ -1,64 +1,79 @@
-# SpaceCadetPinball
-**Summary:** Reverse engineering of `3D Pinball for Windows – Space Cadet`, a game bundled with Windows.
+<!-- markdownlint-disable-file MD033 -->
 
-**How to play:** Place compiled executable into a folder containing original game resources (not included).\
+# SpaceCadetPinball
+
+## Summary
+
+Reverse engineering of `3D Pinball for Windows – Space Cadet`, a game bundled with Windows.
+
+## How to play
+
+Place compiled executable into a folder containing original game resources (not included).\
 Supports data files from Windows and Full Tilt versions of the game.
 
-**Known source ports:**
-| Platform | Author | URL |
-| --- | --- | --- |
-| PS Vita | Axiom | <https://github.com/suicvne/SpaceCadetPinball_Vita> |
-| Emscripten | alula | <https://github.com/alula/SpaceCadetPinball> <br> Play online: https://alula.github.io/SpaceCadetPinball |
-| Nintendo Switch | averne | https://github.com/averne/SpaceCadetPinball-NX |
+## Known source ports
+
+| Platform        | Author | URL                                                                                                        |
+| --------------- | ------ | ---------------------------------------------------------------------------------------------------------- |
+| PS Vita         | Axiom  | <https://github.com/suicvne/SpaceCadetPinball_Vita>                                                        |
+| Emscripten      | alula  | <https://github.com/alula/SpaceCadetPinball> <br> Play online: <https://alula.github.io/SpaceCadetPinball> |
+| Nintendo Switch | averne | <https://github.com/averne/SpaceCadetPinball-NX>                                                           |
 
 Platforms covered by this project: desktop Windows, Linux and macOS.
-\
-\
-\
-\
-\
-\
-**Source:**
- * `pinball.exe` from `Windows XP` (SHA-1 `2A5B525E0F631BB6107639E2A69DF15986FB0D05`) and its public PDB
- * `CADET.EXE` 32bit version from `Full Tilt! Pinball` (SHA-1 `3F7B5699074B83FD713657CD94671F2156DBEDC4`)
 
-**Tools used:** `Ghidra`, `Ida`, `Visual Studio`
+## Source
 
-**What was done:**
- * All structures were populated, globals and locals named.
- * All subs were decompiled, C pseudo code was converted to compilable C++. Loose (namespace?) subs were assigned to classes.
+* `pinball.exe` from `Windows XP` (SHA-1 `2A5B525E0F631BB6107639E2A69DF15986FB0D05`) and its public PDB
+* `CADET.EXE` 32bit version from `Full Tilt! Pinball` (SHA-1 `3F7B5699074B83FD713657CD94671F2156DBEDC4`)
 
-**Compiling:**
+## Tools used
 
-Project uses `C++11` and depends on `SDL2` libs.\
-On Windows:\
+`Ghidra`, `Ida`, `Visual Studio`
+
+## What was done
+
+* All structures were populated, globals and locals named.
+* All subs were decompiled, C pseudo code was converted to compilable C++. Loose (namespace?) subs were assigned to classes.
+
+## Compiling
+
+Project uses `C++11` and depends on `SDL2` libs.
+
+### On Windows
+
 Download and unpack devel packages for `SDL2` and `SDL2_mixer`.\
-Set paths to them in CMakeLists.txt, see suggested placement in /Libs.\
-Compile with Visual Studio; tested with 2019. 
+Set paths to them in `CMakeLists.txt`, see suggested placement in `/Libs`.\
+Compile with Visual Studio; tested with 2019.
 
-On Linux:\
+### On Linux
+
 Install devel packages for `SDL2` and `SDL2_mixer`.\
 Compile with CMake; tested with GCC 10, Clang 11.\
-To cross-compile for Windows, install a 64-bit version of mingw and its `SDL2` and `SDL2_mixer` distributions, then use the `mingwcc.cmake` toolchain. 
+To cross-compile for Windows, install a 64-bit version of mingw and its `SDL2` and `SDL2_mixer` distributions, then use the `mingwcc.cmake` toolchain.
 
-On macOS:\
-**Homebrew**: Install the `SDL2`, `SDL2_mixer` homebrew packages.\
-**MacPorts**: Install the `libSDL2`, `libSDL2_mixer` macports packages.\
-Compile with CMake. Ensure that `CMAKE_OSX_ARCHITECTURES` variable is set for either `x86_64` Apple Intel or `arm64` for Apple Silicon.\
+### On macOS
+
+* **Homebrew**: Install the `SDL2`, `SDL2_mixer` homebrew packages.
+* **MacPorts**: Install the `libSDL2`, `libSDL2_mixer` macports packages.
+
+Compile with CMake. Ensure that `CMAKE_OSX_ARCHITECTURES` variable is set for either `x86_64` Apple Intel or `arm64` for Apple Silicon.
+
 Tested with: macOS Big Sur (Intel) with Xcode 13 & macOS Montery Beta (Apple Silicon) with Xcode 13.
 
-**Plans:**
- * ~~Decompile original game~~
- * ~~Resizable window, scaled graphics~~
- * ~~Loader for high-res sprites from CADET.DAT~~
- * Misc features of Full Tilt: 3 music tracks, multiball, centered textboxes, etc.
- * Cross-platform port
-   * Using SDL2, SDL2_mixer, ImGui
-   * Maybe: Android port
- * Maybe x2: support for other two tables 
-   * Table specific BL (control interactions and missions) is hardcoded, othere parts might be also patched
+## Plans
 
-**On 64-bit bug that killed the game:**\
+* ~~Decompile original game~~
+* ~~Resizable window, scaled graphics~~
+* ~~Loader for high-res sprites from CADET.DAT~~
+* Misc features of Full Tilt: 3 music tracks, multiball, centered textboxes, etc.
+* Cross-platform port
+  * Using SDL2, SDL2_mixer, ImGui
+  * Maybe: Android port
+* Maybe x2: support for other two tables
+  * Table specific BL (control interactions and missions) is hardcoded, othere parts might be also patched
+
+## On 64-bit bug that killed the game
+
 I did not find it, decompiled game worked in x64 mode on the first try.\
 It was either lost in decompilation or introduced in x64 port/not present in x86 build.\
 Based on public description of the bug (no ball collision), I guess that the bug was in `TEdgeManager::TestGridBox`


### PR DESCRIPTION
I linted `README.md` to make more easier to quote each sections.

ex: <https://github.com/eggplants/SpaceCadetPinball/tree/lint_doc#on-linux>