### PR TITLE
Fix compiler warnings

### DIFF
--- a/SpaceCadetPinball/TComponentGroup.cpp
+++ b/SpaceCadetPinball/TComponentGroup.cpp
@@ -45,7 +45,7 @@ int TComponentGroup::Message(int code, float value)
 		if (value > 0.0f)
 			this->Timer = timer::set(value, this, NotifyTimerExpired);
 	}
-	else if (code <= 1007 || code > 1011 && code != 1020 && code != 1022)
+	else if (code <= 1007 || (code > 1011 && code != 1020 && code != 1022))
 	{
 		for (auto component : List)
 		{

--- a/SpaceCadetPinball/TEdgeSegment.cpp
+++ b/SpaceCadetPinball/TEdgeSegment.cpp
@@ -93,8 +93,8 @@ TEdgeSegment* TEdgeSegment::install_wall(float* floatArr, TCollisionComponent* c
 					vec2.X = centerX2 - centerX1;
 					vec2.Y = centerY2 - center.Y;
 					maths::cross(&vec1, &vec2, &dstVec);
-					if (dstVec.Z > 0.0f && offset > 0.0f ||
-						dstVec.Z < 0.0f && offset < 0.0f)
+					if ((dstVec.Z > 0.0f && offset > 0.0f) ||
+						(dstVec.Z < 0.0f && offset < 0.0f))
 					{
 						float radius = offset * 1.001f;
 						auto circle = new TCircle(collComp, activeFlagPtr, collisionGroup, &center, radius);

--- a/SpaceCadetPinball/TFlipperEdge.cpp
+++ b/SpaceCadetPinball/TFlipperEdge.cpp
@@ -438,10 +438,10 @@ int TFlipperEdge::is_ball_inside(float x, float y)
 	vector_type testPoint{};
 	float dx = RotOrigin.X - x;
 	float dy = RotOrigin.Y - y;
-	if ((A2.X - A1.X) * (y - A1.Y) - (A2.Y - A1.Y) * (x - A1.X) >= 0.0f &&
+	if (((A2.X - A1.X) * (y - A1.Y) - (A2.Y - A1.Y) * (x - A1.X) >= 0.0f &&
 		(B1.X - A2.X) * (y - A2.Y) - (B1.Y - A2.Y) * (x - A2.X) >= 0.0f &&
 		(B2.X - B1.X) * (y - B1.Y) - (B2.Y - B1.Y) * (x - B1.X) >= 0.0f &&
-		(A1.X - B2.X) * (y - B2.Y) - (A1.Y - B2.Y) * (x - B2.X) >= 0.0f ||
+		(A1.X - B2.X) * (y - B2.Y) - (A1.Y - B2.Y) * (x - B2.X) >= 0.0f) ||
 		dy * dy + dx * dx <= CirclebaseRadiusSq ||
 		(T1.Y - y) * (T1.Y - y) + (T1.X - x) * (T1.X - x) < CircleT1RadiusSq)
 	{


### PR DESCRIPTION
When building with Clang on android, some compiler warnings appear about not using parenthesis on a comparison using && and ||.