### PR TITLE
Fix visual stuttering on WindowsClassic version

### DIFF
--- a/SpaceCadetPinball/options.cpp
+++ b/SpaceCadetPinball/options.cpp
@@ -136,6 +136,9 @@ void options::ReadOptions()
 	Options.BottomTableBumpKey = get_int(nullptr, "Bottom Table Bump key", Options.BottomTableBumpKey);
 	Options.UniformScaling = get_int(nullptr, "Uniform scaling", true);
 	Options.AlternativeRender = get_int(nullptr, "Alternative Render", false);
+	Options.TargetUps = get_int(nullptr, "Target UPS", 120);
+	Options.TargetUps = max(60, Options.TargetUps);
+	Options.TargetUps = min(Options.TargetUps, 360);
 
 	auto defaultLanguage = Languages::English;
 	auto language = static_cast<Languages>(get_int(nullptr, "Language", static_cast<int>(defaultLanguage)));
@@ -235,6 +238,7 @@ void options::uninit()
 	set_int(nullptr, "Uniform scaling", Options.UniformScaling);
 	set_int(nullptr, "Alternative Render", Options.AlternativeRender);
 	set_int(nullptr, "Language", static_cast<int>(Options.Language));
+	set_int(nullptr, "Target UPS", Options.TargetUps);
 }
 
 void options::path_init(LPCSTR regPath)

--- a/SpaceCadetPinball/options.h
+++ b/SpaceCadetPinball/options.h
@@ -59,6 +59,7 @@ struct optionsStruct
 	int Resolution;
 	bool UniformScaling;
 	bool AlternativeRender;
+	int TargetUps;
 	Languages Language;
 };
 

--- a/SpaceCadetPinball/pb.cpp
+++ b/SpaceCadetPinball/pb.cpp
@@ -270,9 +270,13 @@ void pb::frame(float dtMilliSec)
 			// Retained render prevents frame skip. The next best thing - complete refresh at fixed rate. 
 			render::update(false);
 
+			auto targetFps = options::Options.TargetUps / 2.0f;
+			targetFps = max(targetFps, 60.0f); // at least 60
+
 			// Frame time at 60 FPS = 16.(6) ms
-			auto targetTime = 1000 / 60.0f;
+			auto targetTime = 1000.0f / targetFps;
 			frameTime += dtMilliSec;
+
 			if (frameTime >= targetTime)
 			{
 				frameTime = min(frameTime - targetTime, 100);

--- a/SpaceCadetPinball/winmain.cpp
+++ b/SpaceCadetPinball/winmain.cpp
@@ -12,8 +12,6 @@
 #include "splash.h"
 #include "render.h"
 
-const float TargetUPS = 120, TargetFrameTime = 1000 / TargetUPS;
-
 HINSTANCE winmain::hinst = nullptr;
 HWND winmain::hwnd_frame = nullptr;
 HCURSOR winmain::mouse_hsave;
@@ -225,6 +223,11 @@ int winmain::WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 		pb::toggle_demo();
 	else
 		pb::replay_level(0);
+	
+	// To have a smooth display, Updates Per Sec (UPS) should be fps*2.
+	// Defaulted to 125 UPS, to leave some time for rendering.
+	float TargetFrameTime = 1000.0f / options::Options.TargetUps;
+	TargetFrameTime = max(TargetFrameTime, 1);
 
 	DWORD someTimeCounter = 300u, prevTime = 0u, frameStart = timeGetTime();
 	float sleepRemainder = 0, frameDuration = TargetFrameTime;


### PR DESCRIPTION
While the ball moves, it visibly stutters, as if there was an FPS drop.

Turns out that Windows timer resolution, more specifically `Sleep()` is the root cause, its precision is too high.

Set the timer precision to 1ms and sleep for 1ms only. This still doesn't cause much CPU usage but provides a significantly better visual experience.
