### PR TITLE
Minor performance optimizations

### DIFF
--- a/SpaceCadetPinball/Sound.cpp
+++ b/SpaceCadetPinball/Sound.cpp
@@ -114,10 +114,10 @@ void Sound::Enable(int channelFrom, int channelTo, int enableFlag)
 	}
 }
 
-void Sound::Idle()
+void Sound::Idle(bool performCleanup)
 {
 	if (pMem)
-		WaveMix::Pump();
+		WaveMix::Pump(performCleanup);
 }
 
 void Sound::Activate()

--- a/SpaceCadetPinball/Sound.h
+++ b/SpaceCadetPinball/Sound.h
@@ -6,7 +6,7 @@ class Sound
 public:
 	static int Init(HINSTANCE hInstance, int voices, void (* someFuncPtr)(int, MIXWAVE*, int));
 	static void Enable(int channelFrom, int channelTo, int enableFlag);
-	static void Idle();
+	static void Idle(bool performCleanup = true);
 	static void Activate();
 	static void Deactivate();
 	static void Close();

--- a/SpaceCadetPinball/SpaceCadetPinball.vcxproj
+++ b/SpaceCadetPinball/SpaceCadetPinball.vcxproj
@@ -308,6 +308,8 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -350,6 +352,8 @@
       <ConformanceMode>false</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -392,6 +396,8 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -434,6 +440,8 @@
       <ConformanceMode>false</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/SpaceCadetPinball/WaveMix.cpp
+++ b/SpaceCadetPinball/WaveMix.cpp
@@ -550,7 +550,7 @@ int WaveMix::Activate(HANDLE hMixSession, bool fActivate)
 	return 0;
 }
 
-void WaveMix::Pump()
+void WaveMix::Pump(bool performCleanup)
 {
 	Globals = GlobalsActive;
 	if (GlobalsActive)
@@ -567,7 +567,8 @@ void WaveMix::Pump()
 			else
 				xHDR = xHDR->QNext;
 		}
-		FreePlayedBlocks();
+		if (performCleanup)
+			FreePlayedBlocks();
 		while (MixerPlay(GetWaveBlock(), 1));
 	}
 }
@@ -1382,12 +1383,12 @@ int WaveMix::GetConfig(HANDLE hMixSession, MIXCONFIG* lpConfig)
 
 unsigned WaveMix::MyWaveOutGetPosition(HWAVEOUT hWaveOut, int fGoodGetPos)
 {
-	mmtime_tag pmmt{};
+	MMTIME pmmt{};
 
 	if (!fGoodGetPos)
 		return (timeGetTime() - Globals->dwBaseTime) * Globals->PCM.wf.nAvgBytesPerSec / 0x3E8 & 0xFFFFFFF8;
 	pmmt.wType = TIME_BYTES;
-	waveOutGetPosition(hWaveOut, &pmmt, 0xCu);
+	waveOutGetPosition(hWaveOut, &pmmt, sizeof(MMTIME));
 	return Globals->pfnSampleAdjust(pmmt.u.ms, Globals->dwWaveOutPos);
 }
 

--- a/SpaceCadetPinball/WaveMix.h
+++ b/SpaceCadetPinball/WaveMix.h
@@ -151,7 +151,7 @@ public:
 	static MIXWAVE* OpenWave(HANDLE hMixSession, LPCSTR szWaveFilename, HINSTANCE hInst, unsigned int dwFlags);
 	static int FreeWave(HANDLE hMixSession, MIXWAVE* lpMixWave);
 	static int Activate(HANDLE hMixSession, bool fActivate);
-	static void Pump();
+	static void Pump(bool performCleanup = true);
 	static int Play(MIXPLAYPARAMS* lpMixPlayParams);
 
 private:

--- a/SpaceCadetPinball/winmain.cpp
+++ b/SpaceCadetPinball/winmain.cpp
@@ -228,9 +228,10 @@ int winmain::WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	int sleepRemainder = 0, frameDuration = TargetFrameTime;
 	while (true)
 	{
-		if (!someTimeCounter)
+		if (someTimeCounter == 0)
 		{
 			someTimeCounter = 300;
+
 			if (DispFrameRate)
 			{
 				auto curTime = timeGetTime();
@@ -257,7 +258,10 @@ int winmain::WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 			}
 		}
 
-		Sound::Idle();
+		// Don't look for and free already played blocks at every single frame,
+		// as it is quite costly to look up. Only do that "sometimes".
+		bool performSoundCleanup = someTimeCounter == 300;
+		Sound::Idle(performSoundCleanup);
 		if (!ProcessWindowMessages() || bQuit)
 			break;
 


### PR DESCRIPTION
Add `/Ob2` and `/Ot` flags in Release on x86 and x64.

Reduce number of unnecessary `FreePlayedBlocks()` calls. Before this change, the main loop basically called it in every iteration. Call it only after "some time". See screenshots for improvement.

Before:
![before](https://i.imgur.com/iclqySe.png)

After:
![after](https://i.imgur.com/QYJ2HZF.png)

I didn't observe any memory leak, and I believe it should be clearly visible if wav bits were never freed.