### PR TITLE
Fix missing sound when mission is selected

### DIFF
--- a/SpaceCadetPinball/control.cpp
+++ b/SpaceCadetPinball/control.cpp
@@ -1640,7 +1640,7 @@ void control::MissionSpotTargetControl(int code, TPinballComponent* caller)
 		lite->Message(15, 2.0);
 
 		TSound* sound;
-		if (!light_on(&control_lite198_tag) || control_lite198_tag.Component->FlasherActive)
+		if (pb::FullTiltMode && (!light_on(&control_lite198_tag) || control_lite198_tag.Component->FlasherActive))
 		{
 			sound = control_soundwave52_tag.Component;
 		}


### PR DESCRIPTION
When the Mission Targets are hit, a sound is played (sound49d). Except when an actual mission is under selection, then the hit has no sound in 3DPB mode.

I discovered this bug by playing FT mode, and I realized that it plays a weird sound that I previously didn't know. Turned out that 3DPB also tries to play sound52, but the wav file is missing, so it remains silent.

I'd consider this as an outright bug. I believe MS just forgot to ship sound52 with the game files. 

To avoid playing a sound that is unusual to the game lovers, play sound49d.