### PR TITLE
Restart music on replay and on setting change

### DIFF
--- a/SpaceCadetPinball/options.cpp
+++ b/SpaceCadetPinball/options.cpp
@@ -210,7 +210,10 @@ void options::toggle(Menu1 uIDCheckItem)
 		if (!Options.Music)
 			midi::music_stop();
 		else
+		{
+			midi::music_init();
 			midi::play_pb_theme();
+		}
 		return;
 	case Menu1::Show_Menu:
 		Options.ShowMenu = Options.ShowMenu == 0;

--- a/SpaceCadetPinball/pb.cpp
+++ b/SpaceCadetPinball/pb.cpp
@@ -241,7 +241,10 @@ void pb::replay_level(int demoMode)
 	demo_mode = demoMode;
 	mode_change(1);
 	if (options::Options.Music)
+	{
+		midi::music_init();
 		midi::play_pb_theme();
+	}
 	MainTable->Message(1014, static_cast<float>(options::Options.Players));
 }
 


### PR DESCRIPTION
The original Pinball restarts the background music on a new game, or when music is re-enabled