### PR TITLE
Don't autoresume manual pause

### DIFF
--- a/SpaceCadetPinball/winmain.h
+++ b/SpaceCadetPinball/winmain.h
@@ -18,9 +18,9 @@ public:
 	static int check_expiration_date();
 	static HDC _GetDC(HWND hWnd);
 	static int a_dialog(HINSTANCE hInstance, HWND hWnd);
-	static void end_pause();
+	static void end_pause(bool explicitResume = false);
 	static void new_game();
-	static void pause();
+	static void pause(bool autoResume = true);
 	static void help_introduction(HINSTANCE a1, HWND a2);
 	static void Restart();
 private:
@@ -30,6 +30,7 @@ private:
 	static gdrv_bitmap8 gfr_display;
 	static HCURSOR mouse_hsave;
 	static bool restart;
+	static bool explicitPaused;
 
 	static HDC _BeginPaint(HWND hWnd, LPPAINTSTRUCT lpPaint);
 	static void ResetTimer()


### PR DESCRIPTION
You get an annoying behavior when:
- press F3 to pause
- minimize the window
- (keep it in the background, do other stuff)
- bring the window back to focus, accidentally (Alt+Tab)
- game resumes even if I explicitly paused it with F3

This commit makes F3 (and Pause in the menu) require an explicit
resume via F3 (or Pause), other pauses like moving the window still
get resumed automatically.