### PR TITLE
fix the build on OpenBSD

### DIFF
--- a/SpaceCadetPinball/imgui_impl_sdl.cpp
+++ b/SpaceCadetPinball/imgui_impl_sdl.cpp
@@ -55,7 +55,9 @@
 
 // SDL
 #include <SDL.h>
+#ifdef _WIN32
 #include <SDL_syswm.h>
+#endif
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
 #endif


### PR DESCRIPTION
Hi, the build fails on OpenBSD because the X11 include directory is missing. This small change fixes it.

The FindX11.cmake module seems to only trigger on Unix so I'm not putting it in a conditional or anything: https://github.com/Kitware/CMake/blob/3585d117e8da6e3423d515616b3fcc4869cbd817/Modules/FindX11.cmake#L93