### PR TITLE
[early|draft] Enable HiDPI support

### DIFF
--- a/SpaceCadetPinball/winmain.cpp
+++ b/SpaceCadetPinball/winmain.cpp
@@ -67,7 +67,8 @@ int winmain::WinMain(LPCSTR lpCmdLine)
 		pinball::get_rc_string(38, 0),
 		SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
 		800, 556,
-		SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE
+		SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI
+		// Enable HiDPI support by adding SDL_WINDOW_ALLOW_HIGHDPI, only tested on macOS
 	);
 	MainWindow = window;
 	if (!window)


### PR DESCRIPTION
This PR aims to enable HiDPI support. At first glance, it works, running on macOS 12.0.1 on M1 Max.

There are some issues that need to be fixed though:
- [ ] Mouse positioning breaks
- [ ] window scaling can be weird across monitors
- [ ] If HiDPI, ImGui should automatically scale so its shown at a proper legible size without the user configuring it for 2x or whatever
- [ ] Test on platforms other than macOS

These are things above my skill level (c++) for now, so I am going to leave this draft here just for others to see.