### PR TITLE
Fix flipper animation and angle calculation

### DIFF
--- a/SpaceCadetPinball/TFlipper.cpp
+++ b/SpaceCadetPinball/TFlipper.cpp
@@ -137,7 +137,7 @@ void TFlipper::TimerExpired(int timerId, void* caller)
 	auto flip = static_cast<TFlipper*>(caller);
 	int bmpCountSub1 = flip->ListBitmap->size() - 1;
 
-	auto newBmpIndex = static_cast<int>(floor((pb::time_now - flip->InputTime) / flip->TimerTime));
+	auto newBmpIndex = static_cast<int>(floor(flip->FlipperEdge->flipper_angle(pb::time_now) / flip->FlipperEdge->AngleMax * bmpCountSub1 + 0.5));
 	if (newBmpIndex > bmpCountSub1)
 		newBmpIndex = bmpCountSub1;
 	if (newBmpIndex < 0)
@@ -155,7 +155,7 @@ void TFlipper::TimerExpired(int timerId, void* caller)
 	}
 	if (flip->MessageField == 2)
 	{
-		flip->BmpIndex = bmpCountSub1 - newBmpIndex;
+		flip->BmpIndex = newBmpIndex;
 		if (flip->BmpIndex <= 0)
 		{
 			flip->BmpIndex = 0;

--- a/SpaceCadetPinball/TFlipperEdge.cpp
+++ b/SpaceCadetPinball/TFlipperEdge.cpp
@@ -418,19 +418,17 @@ float TFlipperEdge::flipper_angle(float timeNow)
 {
 	if (!FlipperFlag)
 		return Angle1;
-	float angle = (Angle1 - Angle2) / AngleMax * AngleMult;
-	if (angle < 0.0f)
-		angle = -angle;
 
-	if (angle >= 0.0000001f)
-		angle = (timeNow - InputTime) / angle;
+	float currentAngleDuration = fabsf((Angle1 - Angle2) / AngleMax * AngleMult);
+	float currentAngleRatio;
+
+	if (currentAngleDuration >= 0.0000001f)
+		currentAngleRatio = (timeNow - InputTime) / currentAngleDuration;
 	else
-		angle = 1.0;
+		currentAngleRatio = 1.0;
 
-	angle = std::min(1.0f, std::max(angle, 0.0f));
-	if (FlipperFlag == 2)
-		angle = 1.0f - angle;
-	return angle * AngleMax;
+	currentAngleRatio = std::min(1.0f, std::max(currentAngleRatio, 0.0f));
+	return currentAngleRatio * (Angle1 - Angle2) + Angle2;
 }
 
 int TFlipperEdge::is_ball_inside(float x, float y)
@@ -482,8 +480,7 @@ void TFlipperEdge::SetMotion(int code, float value)
 	default: break;
 	}
 
-	if (!FlipperFlag)
-		InputTime = value;
+	InputTime = value;
 	FlipperFlag = code;
 	AngleStopTime = AngleMult + InputTime;
 }


### PR DESCRIPTION
Checked with a slowed down flipper (reduced retractTime and extendTime)
to ensure the flipper position is correct even when not finished while
pressing the flipper control.

Here are videos of the slowed down flippers before and after the patch.

Before this patch, the flipper where always starting their animation from either fully down or fully up, causing glitches when pressing or releasing the flipper button while it is midway:

https://user-images.githubusercontent.com/5435069/183506872-727ee1b0-eb37-44b5-a604-806b57ddb790.mp4

There is also a weird behavior when losing focus, both flipper trigger:

https://user-images.githubusercontent.com/5435069/183506785-afb8e0c6-e8a4-4341-8327-eaf7a8f3b8c8.mp4

With this patch, here is the flipper and ball behavior:

https://user-images.githubusercontent.com/5435069/183504515-35209500-d31f-4cf8-b1f4-9262ecd9b042.mp4

There is no more weird behavior, and the ball can't move through the flippers.

With the normal flipper speed this is barely visible, except the moving flippers when losing and regaining focus (this is what led me to find this issue), but this might cause unexpected behaviors when playing.
