### PR TITLE
fix gui not responding when the game is paused

### DIFF
--- a/SpaceCadetPinball/winmain.cpp
+++ b/SpaceCadetPinball/winmain.cpp
@@ -898,7 +898,7 @@ int winmain::ProcessWindowMessages()
 {
 	static auto idleWait = 0;
 	SDL_Event event;
-	if (has_focus && !single_step)
+	if (has_focus)
 	{
 		idleWait = static_cast<int>(TargetFrameTime.count());
 		while (SDL_PollEvent(&event))


### PR DESCRIPTION
When the game is paused (with F3), the GUI become less and less responsive to mouse and keyboard:

https://user-images.githubusercontent.com/5435069/183508402-0d3d400b-42be-4814-8b6f-30cf414a0967.mp4

The patch keep the polling of input event active even when the game is paused, by not checking single_step.
The resulting behavior is a fluid GUI even when the game is paused:

https://user-images.githubusercontent.com/5435069/183508680-cd8046ed-4ff6-494d-99fe-4789d434ad20.mp4


