### PR TITLE
Add FullTilt lane light behavior

### DIFF
--- a/SpaceCadetPinball/control.cpp
+++ b/SpaceCadetPinball/control.cpp
@@ -1349,10 +1349,10 @@ void control::ReentryLanesRolloverControl(MessageCode code, TPinballComponent* c
 		{
 			if (light->LightOnFlag)
 			{
-                if (!pb::FullTiltMode)
-                {
-                    light->Message(MessageCode::TLightResetAndTurnOff, 0.0);
-                }
+				if (!pb::FullTiltMode)
+				{
+					light->Message(MessageCode::TLightResetAndTurnOff, 0.0);
+				}
 			}
 			else
 			{
@@ -1404,10 +1404,10 @@ void control::LaunchLanesRolloverControl(MessageCode code, TPinballComponent* ca
 		{
 			if (light->LightOnFlag)
 			{
-                if (!pb::FullTiltMode)
-                {
-                    light->Message(MessageCode::TLightResetAndTurnOff, 0.0);
-                }
+				if (!pb::FullTiltMode)
+				{
+					light->Message(MessageCode::TLightResetAndTurnOff, 0.0);
+				}
 			}
 			else
 			{

--- a/SpaceCadetPinball/control.cpp
+++ b/SpaceCadetPinball/control.cpp
@@ -1349,7 +1349,10 @@ void control::ReentryLanesRolloverControl(MessageCode code, TPinballComponent* c
 		{
 			if (light->LightOnFlag)
 			{
-				light->Message(MessageCode::TLightResetAndTurnOff, 0.0);
+                if (!pb::FullTiltMode)
+                {
+                    light->Message(MessageCode::TLightResetAndTurnOff, 0.0);
+                }
 			}
 			else
 			{
@@ -1401,7 +1404,10 @@ void control::LaunchLanesRolloverControl(MessageCode code, TPinballComponent* ca
 		{
 			if (light->LightOnFlag)
 			{
-				light->Message(MessageCode::TLightResetAndTurnOff, 0.0);
+                if (!pb::FullTiltMode)
+                {
+                    light->Message(MessageCode::TLightResetAndTurnOff, 0.0);
+                }
 			}
 			else
 			{


### PR DESCRIPTION
In the FullTilt version, lane rollover lights are not turned off when a ball passes over them. This PR fixes this difference.