### PR TITLE
Fix missing includes in options.h

### DIFF
--- a/SpaceCadetPinball/options.h
+++ b/SpaceCadetPinball/options.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "pch.h"
+#include <string>
+#include <SDL_mixer.h>
+
 enum class Msg : int;
 
 enum class Menu1:int


### PR DESCRIPTION
I have no idea how it worked otherwise, but it failed to compile on my system (Debian 9):
```
In file included from SpaceCadetPinball/Sound.cpp:1:0:
SpaceCadetPinball/options.h:96:7: error: ‘string’ in namespace ‘std’ does not name a type
SpaceCadetPinball/options.h:114:35: error: ‘MIX_MAX_VOLUME’ was not declared in this scope
SpaceCadetPinball/options.h:120:21: error: ‘LPCSTR’ has not been declared
SpaceCadetPinball/options.h:121:22: error: ‘LPCSTR’ has not been declared
SpaceCadetPinball/options.h:122:14: error: ‘string’ in namespace ‘std’ does not name a type
SpaceCadetPinball/options.h:123:25: error: ‘LPCSTR’ has not been declared
SpaceCadetPinball/options.h:123:45: error: ‘LPCSTR’ has not been declared
SpaceCadetPinball/options.h:124:25: error: ‘LPCSTR’ has not been declared
SpaceCadetPinball/options.h:125:24: error: ‘LPCSTR’ has not been declared
SpaceCadetPinball/options.h:126:34: error: ‘string’ in namespace ‘std’ does not name a type
SpaceCadetPinball/options.h:127:34: error: ‘string’ in namespace ‘std’ does not name a type
SpaceCadetPinball/options.h:134:14: error: ‘map’ in namespace ‘std’ does not name a template type
SpaceCadetPinball/options.h:140:34: error: ‘ImGuiContext’ has not been declared
SpaceCadetPinball/options.h:140:53: error: ‘ImGuiSettingsHandler’ has not been declared
SpaceCadetPinball/options.h:141:15: error: expected ‘;’ at end of member declaration
SpaceCadetPinball/options.h:141:47: error: expected ‘)’ before ‘*’ token
SpaceCadetPinball/options.h:142:34: error: ‘ImGuiContext’ has not been declared
SpaceCadetPinball/options.h:142:53: error: ‘ImGuiSettingsHandler’ has not been declared
SpaceCadetPinball/options.h:142:84: error: ‘ImGuiTextBuffer’ has not been declared
SpaceCadetPinball/options.h:143:20: error: ‘string’ in namespace ‘std’ does not name a type
SpaceCadetPinball/options.h:144:36: error: ‘string’ in namespace ‘std’ does not name a type
SpaceCadetPinball/options.h:144:60: error: ‘string’ in namespace ‘std’ does not name a type
```