### PR TITLE
Fix crashing with some versions of SDL

### DIFF
--- a/SpaceCadetPinball/winmain.cpp
+++ b/SpaceCadetPinball/winmain.cpp
@@ -109,7 +109,7 @@ int winmain::WinMain(LPCSTR lpCmdLine)
 	ImGuiIO& io = ImGui::GetIO();
 	ImIO = &io;
 
-	auto prefPath = SDL_GetPrefPath(nullptr, "SpaceCadetPinball");
+	auto prefPath = SDL_GetPrefPath("", "SpaceCadetPinball");
 	auto iniPath = std::string(prefPath) + "imgui_pb.ini";
 	io.IniFilename = iniPath.c_str();
 


### PR DESCRIPTION
In SDL version 2.0.5 as provided in Debian 9, passing `nullptr` as the first argument to **SDL_GetPrefPath(3)** would crash the program:
```
GNU gdb (Debian 7.12-6) 7.12.0.20161007-git
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from bin/SpaceCadetPinball...done.
(gdb) r
Starting program: bin/SpaceCadetPinball 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7fffee89b700 (LWP 1038330)]
[New Thread 0x7fffe763a700 (LWP 1038759)]
[New Thread 0x7fffe6e39700 (LWP 1038760)]
[New Thread 0x7fffe6638700 (LWP 1038761)]
[New Thread 0x7fffe5e37700 (LWP 1038762)]
[New Thread 0x7fffe5636700 (LWP 1038763)]
[New Thread 0x7fffe4e35700 (LWP 1038764)]
[New Thread 0x7fffe4634700 (LWP 1038765)]
[New Thread 0x7fffe3e33700 (LWP 1038766)]
[New Thread 0x7fffe3632700 (LWP 1038767)]
[New Thread 0x7fffe2e31700 (LWP 1038768)]
[New Thread 0x7fffe2630700 (LWP 1038769)]
[New Thread 0x7fffe1e2f700 (LWP 1038770)]
[New Thread 0x7fffe162e700 (LWP 1038771)]
[New Thread 0x7fffe0e2d700 (LWP 1038772)]
[New Thread 0x7fffe062c700 (LWP 1038773)]
[New Thread 0x7fffdfe2b700 (LWP 1038774)]
[New Thread 0x7fffdf3f0700 (LWP 1038945)]
Using SDL renderer: opengl

Thread 1 "SpaceCadetPinba" received signal SIGSEGV, Segmentation fault.
strlen () at ../sysdeps/x86_64/strlen.S:106
106	../sysdeps/x86_64/strlen.S: No such file or directory.
(gdb) bt
#0  strlen () at ../sysdeps/x86_64/strlen.S:106
#1  0x00007ffff777172f in ?? () from /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0
#2  0x00005555555d63be in winmain::WinMain (lpCmdLine=0x7fffffffe490 "")
    at SpaceCadetPinball/winmain.cpp:112
#3  0x00005555555c7bdd in MainActual (lpCmdLine=0x7fffffffe490 "")
    at SpaceCadetPinball/SpaceCadetPinball.cpp:14
#4  0x00005555555b4333 in main (argc=1, argv=0x7fffffffe5a8)
    at SpaceCadetPinball/SpaceCadetPinball.cpp:26
(gdb) frame 2
#2  0x00005555555d63be in winmain::WinMain (lpCmdLine=0x7fffffffe490 "")
    at SpaceCadetPinball/winmain.cpp:112
112		auto prefPath = SDL_GetPrefPath(nullptr, "SpaceCadetPinball");
```

I think it is worth to fix as the game fully worked after applying #162 and this patch (guessing #163).