### PR TITLE
Allow loading data files with lowercase name

### DIFF
--- a/SpaceCadetPinball/midi.h
+++ b/SpaceCadetPinball/midi.h
@@ -110,6 +110,7 @@ private:
 
 	static void StopPlayback();
 	static Mix_Music* load_track(std::string fileName);
+	static Mix_Music* load_track_sub(std::string fileName, bool isMidi);
 	static Mix_Music* TrackToMidi(MidiTracks track);
 	static std::vector<uint8_t>* MdsToMidi(std::string file);
 };

--- a/SpaceCadetPinball/pb.cpp
+++ b/SpaceCadetPinball/pb.cpp
@@ -131,16 +131,22 @@ void pb::SelectDatFile(const std::vector<const char*>& dataSearchPaths)
 	DatFileName.clear();
 	FullTiltDemoMode = FullTiltMode = false;
 
-	std::string datFileNames[3]
+	std::string datFileNames[]
 	{
 		"CADET.DAT",
 		"PINBALL.DAT",
 		"DEMO.DAT",
+		"cadet.dat",
+		"pinball.dat",
+		"demo.dat",
 	};
 
 	// Default game data test order: CADET.DAT, PINBALL.DAT, DEMO.DAT
 	if (options::Options.Prefer3DPBGameData)
+	{
 		std::swap(datFileNames[0], datFileNames[1]);
+		std::swap(datFileNames[3], datFileNames[4]);
+	}
 	for (auto path : dataSearchPaths)
 	{
 		if (DatFileName.empty() && path)
@@ -154,11 +160,10 @@ void pb::SelectDatFile(const std::vector<const char*>& dataSearchPaths)
 				{
 					fclose(datFile);
 					DatFileName = datFileName;
-					if (datFileName == "CADET.DAT")
+					if (strcasecmp(datFileName.c_str(), "cadet.dat") == 0)
 						FullTiltMode = true;
-					if (datFileName == "DEMO.DAT")
+					else if (strcasecmp(datFileName.c_str(), "demo.dat") == 0)
 						FullTiltDemoMode = FullTiltMode = true;
-
 					printf("Loading game from: %s\n", datFilePath.c_str());
 					break;
 				}


### PR DESCRIPTION
Those original data files are usually have uppercase names as installed in Windows, but due to the case-insensitive nature of Windows, it is possible to get lowercased names when copying them out, especially when using some older Windows versions (such as Windows 9x) or older file systems. As a result, when attempt using it in a case-sensitive system, the program won't load these data files with lowercase name.